### PR TITLE
[ENTVTX-514] avoid using .openshiftio directory in tests

### DIFF
--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -7,6 +7,6 @@
     <property name="namespace.use.current">true</property>
     <property name="env.init.enabled">true</property>
     <property name="enableImageStreamDetection">false</property>
-    <property name="env.dependencies">file://${basedir}/.openshiftio/service.yaml</property>
+    <property name="env.dependencies">file://${basedir}/target/test-classes/database.yml</property>
   </extension>
 </arquillian>

--- a/src/test/resources/database.yml
+++ b/src/test/resources/database.yml
@@ -10,15 +10,19 @@ items:
       app: my-database
     name: my-database
   spec:
+    lookupPolicy:
+      local: false
     tags:
     - annotations:
-        openshift.io/imported-from: centos/postgresql-95-centos7
+        openshift.io/imported-from: openshift/postgresql-92-centos7
       from:
         kind: DockerImage
-        name: centos/postgresql-95-centos7
+        name: openshift/postgresql-92-centos7
       generation: null
       importPolicy: {}
       name: latest
+      referencePolicy:
+        type: ""
   status:
     dockerImageRepository: ""
 - apiVersion: v1
@@ -40,7 +44,6 @@ items:
     template:
       metadata:
         annotations:
-          openshift.io/container.my-database.image.entrypoint: '["container-entrypoint","run-postgresql"]'
           openshift.io/generated-by: OpenShiftNewApp
         creationTimestamp: null
         labels:
@@ -78,7 +81,13 @@ items:
           kind: ImageStreamTag
           name: my-database:latest
       type: ImageChange
-  status: {}
+  status:
+    availableReplicas: 0
+    latestVersion: 0
+    observedGeneration: 0
+    replicas: 0
+    unavailableReplicas: 0
+    updatedReplicas: 0
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
The `database.yml` file is a copy of `.openshiftio/service.yaml`. As you see, the previous file was slightly different from the one in `.openshiftio`.